### PR TITLE
Update IEventRepository for version handling and improve error management

### DIFF
--- a/src/domain/repositories/iEventRepository.ts
+++ b/src/domain/repositories/iEventRepository.ts
@@ -7,6 +7,9 @@ export type EventRepositoryErrorCode =
   (typeof EventRepositoryErrorCode)[keyof typeof EventRepositoryErrorCode]
 
 export interface IEventRepository {
-  getEventsByAggregateId(aggregateId: string): Promise<DomainEvent[]>
+  getEventsByAggregateId(
+    aggregateId: string,
+    version: number,
+  ): Promise<DomainEvent[]>
   saveEvent(event: DomainEvent): Promise<void>
 }

--- a/test/infrastructure/eventDdbRepository.getEventsByAggregatedId.db.test.ts
+++ b/test/infrastructure/eventDdbRepository.getEventsByAggregatedId.db.test.ts
@@ -138,4 +138,79 @@ describe('EventDdbRepository.getEventsByAggregateId', () => {
       expect(result).toEqual(events)
     })
   })
+
+  describe('Given multiple events exist for the aggregateId and a specific version', () => {
+    const aggregateId = randomUUID()
+    const events = [
+      new DomainEvent({
+        aggregateId,
+        createdAt: new Date('2025-01-01T12:34:56.789Z').toISOString(),
+        name: DomainEventName.WidgetCreated,
+        payload: {name: 'WidgetCreated'},
+        version: 1,
+      }),
+      new DomainEvent({
+        aggregateId,
+        createdAt: new Date('2025-01-02T12:34:56.789Z').toISOString(),
+        name: DomainEventName.WidgetNameChanged,
+        payload: {name: 'WidgetNameChanged'},
+        version: 2,
+      }),
+      new DomainEvent({
+        aggregateId,
+        createdAt: new Date('2025-01-03T12:34:56.789Z').toISOString(),
+        name: DomainEventName.WidgetDescriptionChanged,
+        payload: {name: 'WidgetDescriptionChanged'},
+        version: 3,
+      }),
+      new DomainEvent({
+        aggregateId,
+        createdAt: new Date('2025-01-04T12:34:56.789Z').toISOString(),
+        name: DomainEventName.WidgetDeleted,
+        payload: {name: 'WidgetDeleted'},
+        version: 4,
+      }),
+    ]
+    beforeEach(async () => {
+      const input: BatchWriteCommandInput = {
+        RequestItems: {
+          [TABLE_NAME]: events.map((event) => ({
+            PutRequest: {
+              Item: {
+                PK: event.aggregateId,
+                SK: event.version,
+                created: event.createdAt,
+                name: event.name,
+                payload: event.payload,
+              },
+            },
+          })),
+        },
+      }
+      const command = new BatchWriteCommand(input)
+      await ddbDocClient.send(command)
+    })
+    afterEach(() => {
+      const input: BatchWriteCommandInput = {
+        RequestItems: {
+          [TABLE_NAME]: events.map((event) => ({
+            DeleteRequest: {
+              Key: {
+                PK: event.aggregateId,
+                SK: event.version,
+              },
+            },
+          })),
+        },
+      }
+      const command = new BatchWriteCommand(input)
+      return ddbDocClient.send(command)
+    })
+    it('returns an array of events with versions greater than the specified version', async () => {
+      const repository = new EventDdbRepository()
+      const result = await repository.getEventsByAggregateId(aggregateId, 2)
+      const expected = events.filter((event) => event.version >= 2)
+      expect(result).toEqual(expected)
+    })
+  })
 })

--- a/test/infrastructure/eventDdbRepository.saveEvent.db.test.ts
+++ b/test/infrastructure/eventDdbRepository.saveEvent.db.test.ts
@@ -103,7 +103,7 @@ describe('EventDdbRepository.saveEvent', () => {
     it('does not save the event', async () => {
       const repository = new EventDdbRepository()
       await expect(repository.saveEvent(event)).rejects.toThrow(
-        EventRepositoryErrorCode.EventAlreadyExists,
+        ConditionalCheckFailedException,
       )
     })
   })
@@ -199,7 +199,7 @@ describe('EventDdbRepository.saveEvent', () => {
       const repository = new EventDdbRepository()
       await expect(
         repository.saveEvent(eventVersion1Duplicate),
-      ).rejects.toThrow(EventRepositoryErrorCode.EventAlreadyExists)
+      ).rejects.toThrow(ConditionalCheckFailedException)
     })
   })
 
@@ -255,11 +255,9 @@ describe('EventDdbRepository.saveEvent', () => {
       const command = new BatchWriteCommand(input)
       await ddbDocClient.send(command)
     })
-    it('does not save the event', async () => {
+    it('saves the event', async () => {
       const repository = new EventDdbRepository()
-      await expect(repository.saveEvent(eventVersion1)).rejects.toThrow(
-        EventRepositoryErrorCode.EventAlreadyExists,
-      )
+      await expect(repository.saveEvent(eventVersion1)).resolves.toBeUndefined()
     })
   })
 })

--- a/test/infrastructure/eventDdbRepository.saveEvent.mock.test.ts
+++ b/test/infrastructure/eventDdbRepository.saveEvent.mock.test.ts
@@ -1,16 +1,15 @@
 import {randomUUID} from 'node:crypto'
+import {ConditionalCheckFailedException} from '@aws-sdk/client-dynamodb'
 import {
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
 } from '@aws-sdk/lib-dynamodb'
 import {mockClient} from 'aws-sdk-client-mock'
-import {toHaveReceivedCommand} from 'aws-sdk-client-mock-vitest'
 import {
   DomainEvent,
   DomainEventName,
 } from '../../src/domain/entities/domainEvent'
-import {EventRepositoryErrorCode} from '../../src/domain/repositories/iEventRepository'
 import {EventDdbRepository} from '../../src/infrastructure/eventDdbRepository'
 
 const ddbMock = mockClient(DynamoDBDocumentClient)
@@ -46,27 +45,17 @@ describe('EventDdbRepository.saveEvent', () => {
       version: 1,
     })
     beforeEach(() => {
-      ddbMock.on(QueryCommand).resolves({
-        Items: [
-          {
-            PK: event.aggregateId,
-            SK: event.version,
-            created: event.createdAt,
-            name: event.name,
-            payload: event.payload,
-          },
-        ],
+      const error = new ConditionalCheckFailedException({
+        $metadata: {},
+        message: 'The conditional request failed',
       })
+      ddbMock.on(PutCommand).rejects(error)
     })
     it('throws an error, EventAlreadyExists', async () => {
       const repository = new EventDdbRepository()
       await expect(repository.saveEvent(event)).rejects.toThrow(
-        EventRepositoryErrorCode.EventAlreadyExists,
+        ConditionalCheckFailedException,
       )
-    })
-    it('does not save the event', async () => {
-      const repository = new EventDdbRepository()
-      expect(ddbMock).not.toHaveReceivedCommand(PutCommand)
     })
   })
   describe('Given an event which version is lower than the existing event', () => {
@@ -97,15 +86,9 @@ describe('EventDdbRepository.saveEvent', () => {
         ],
       })
     })
-    it('throws an error, EventAlreadyExists', async () => {
+    it('saves the event', async () => {
       const repository = new EventDdbRepository()
-      await expect(repository.saveEvent(event)).rejects.toThrow(
-        EventRepositoryErrorCode.EventAlreadyExists,
-      )
-    })
-    it('does not save the event', async () => {
-      const repository = new EventDdbRepository()
-      expect(ddbMock).not.toHaveReceivedCommand(PutCommand)
+      await expect(repository.saveEvent(event)).resolves.toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Introduce a version parameter in `getEventsByAggregateId` to filter events by version. Refactor `saveEvent` method to enhance error handling by using `ConditionalCheckFailedException` instead of a custom error code. Update related tests accordingly.