### PR TITLE
✨ Add error handling test for WidgetQueryDdbRepository.getWidgetById

### DIFF
--- a/test/infrastructure/widgetQueryDdbRepository.getWidgetById.mock.test.ts
+++ b/test/infrastructure/widgetQueryDdbRepository.getWidgetById.mock.test.ts
@@ -43,4 +43,15 @@ describe('WidgetQueryDdbRepository.getWidgetById', () => {
       )
     })
   })
+  describe('Given an error when getting the widget aggregate', () => {
+    const aggregateId = randomUUID()
+    beforeEach(() => {
+      ddbMock.on(GetCommand).rejects(new Error('Unknown error'))
+    })
+    it('throws AggregateNotFound error', async () => {
+      await expect(repository.getWidgetById(aggregateId)).rejects.toThrow(
+        WidgetQueryRepositoryErrorCode.InternalError,
+      )
+    })
+  })
 })


### PR DESCRIPTION
This pull request includes a new test case in the `test/infrastructure/widgetQueryDdbRepository.getWidgetById.mock.test.ts` file to handle error scenarios when fetching a widget by its ID.

Testing improvements:

* Added a new test case to handle the scenario where an error occurs while getting the widget aggregate, ensuring that an `AggregateNotFound` error is thrown.