### PR TITLE
✨ Update WidgetQueryDdbRepository to use 'last_events' and add tests for listWidgets

### DIFF
--- a/src/infrastructure/widgetQueryDdbRepository.ts
+++ b/src/infrastructure/widgetQueryDdbRepository.ts
@@ -47,27 +47,26 @@ export class WidgetQueryDdbRepository implements IWidgetQueryRepository {
     item: Record<string, unknown>,
   ): Promise<WidgetDTO> {
     // lastEventsを取得
-    const {PK: aggregateId, lastEvents} = item as {
+    const {PK: aggregateId, last_events: lastEvents} = item as {
       PK: string
-      lastEvents: Record<number, unknown>
+      last_events: Record<number, unknown>
     }
 
     // lastEventsをEventテーブルに永続化
     for (const [version, _event] of Object.entries(lastEvents ?? {})) {
-      const event = _event as {
-        createdAt: string
+      const params = _event as {
+        created: string
         name: DomainEventName
         payload: Record<string, unknown>
       }
-      await this.eventRepository.saveEvent(
-        new DomainEvent({
-          aggregateId,
-          createdAt: event.createdAt,
-          name: event.name,
-          payload: event.payload,
-          version: Number(version),
-        }),
-      )
+      const event = new DomainEvent({
+        aggregateId,
+        createdAt: params.created,
+        name: params.name,
+        payload: params.payload,
+        version: Number(version),
+      })
+      await this.eventRepository.saveEvent(event)
     }
 
     const widget = new Widget({

--- a/test/infrastructure/widgetQueryDdbRepository.getWidgetById.db.test.ts
+++ b/test/infrastructure/widgetQueryDdbRepository.getWidgetById.db.test.ts
@@ -41,9 +41,9 @@ describe('WidgetQueryDdbRepository.getWidgetById', () => {
           PK: aggregateId,
           created: createdAt,
           type: AggregateType.Widget,
-          lastEvents: {
+          last_events: {
             1: {
-              createdAt: createdAt,
+              created: createdAt,
               name: DomainEventName.WidgetCreated,
               payload: {
                 name: 'Widget 1',
@@ -86,7 +86,7 @@ describe('WidgetQueryDdbRepository.getWidgetById', () => {
                   PK: aggregateId,
                   created: createdAt1,
                   type: AggregateType.Widget,
-                  lastEvents: {
+                  last_events: {
                     2: {
                       createdAt: createdAt3,
                       name: DomainEventName.WidgetNameChanged,
@@ -154,9 +154,9 @@ describe('WidgetQueryDdbRepository.getWidgetById', () => {
                   PK: aggregateId,
                   created: createdAt1,
                   type: AggregateType.Widget,
-                  lastEvents: {
+                  last_events: {
                     3: {
-                      createdAt: createdAt3,
+                      created: createdAt3,
                       name: DomainEventName.WidgetDescriptionChanged,
                       payload: {
                         name: 'Widget One',
@@ -176,7 +176,7 @@ describe('WidgetQueryDdbRepository.getWidgetById', () => {
                 Item: {
                   PK: aggregateId,
                   SK: 1,
-                  createdAt: createdAt2,
+                  created: createdAt2,
                   name: DomainEventName.WidgetNameChanged,
                   payload: {
                     name: 'Widget One',

--- a/test/infrastructure/widgetQueryDdbRepository.listWidgets.db.test.ts
+++ b/test/infrastructure/widgetQueryDdbRepository.listWidgets.db.test.ts
@@ -1,0 +1,123 @@
+import {randomUUID} from 'node:crypto'
+import {
+  BatchWriteCommand,
+  type BatchWriteCommandInput,
+} from '@aws-sdk/lib-dynamodb'
+import type {WidgetDTO} from '../../src/application/dto/widgetDTO'
+import {AggregateType} from '../../src/domain/entities/aggregate'
+import {DomainEventName} from '../../src/domain/entities/domainEvent'
+import {ddbDocClient} from '../../src/infrastructure/ddbDocClient'
+import {EventDdbRepository} from '../../src/infrastructure/eventDdbRepository'
+import {SnapshotDdbRepository} from '../../src/infrastructure/snapshotDdbRepository'
+import {WidgetQueryDdbRepository} from '../../src/infrastructure/widgetQueryDdbRepository'
+
+const TABLE_NAME_AGGREGATE = 'Aggregate'
+
+describe('WidgetQueryDdbRepository.listWidgets', () => {
+  const eventRepository = new EventDdbRepository()
+  const snapshotRepository = new SnapshotDdbRepository()
+  const repository = new WidgetQueryDdbRepository({
+    eventRepository,
+    snapshotRepository,
+  })
+
+  describe('Given no widgets', () => {
+    it('returns an empty array', async () => {
+      const widgets = await repository.listWidgets()
+      expect(widgets).toEqual([])
+    })
+  })
+
+  describe('Given some widgets', () => {
+    const aggregateId1 = randomUUID()
+    const aggregateId2 = randomUUID()
+    const repository = new WidgetQueryDdbRepository({
+      eventRepository,
+      snapshotRepository,
+    })
+    beforeEach(() => {
+      const input: BatchWriteCommandInput = {
+        RequestItems: {
+          [TABLE_NAME_AGGREGATE]: [
+            {
+              PutRequest: {
+                Item: {
+                  PK: aggregateId1,
+                  created: new Date('2022-01-01T00:00:00.000Z').toISOString(),
+                  type: AggregateType.Widget,
+                  last_events: {
+                    1: {
+                      created: new Date(
+                        '2022-01-01T00:00:00.000Z',
+                      ).toISOString(),
+                      name: DomainEventName.WidgetCreated,
+                      payload: {
+                        name: 'Widget 1',
+                        description: 'Description 1',
+                        stock: 1,
+                      },
+                    },
+                  },
+                  version: 0,
+                },
+              },
+            },
+            {
+              PutRequest: {
+                Item: {
+                  PK: aggregateId2,
+                  created: new Date('2022-01-02T00:00:00.000Z').toISOString(),
+                  type: AggregateType.Widget,
+                  last_events: {
+                    1: {
+                      created: new Date(
+                        '2022-01-02T00:00:00.000Z',
+                      ).toISOString(),
+                      name: DomainEventName.WidgetCreated,
+                      payload: {
+                        name: 'Widget 2',
+                        description: 'Description 2',
+                        stock: 2,
+                      },
+                    },
+                  },
+                  version: 0,
+                },
+              },
+            },
+          ],
+        },
+      }
+      const command = new BatchWriteCommand(input)
+      ddbDocClient.send(command)
+    })
+    it('returns the widgets', async () => {
+      const widgets = await repository.listWidgets()
+      const expectedWidgets: WidgetDTO[] = [
+        {
+          aggregateId: aggregateId1,
+          createdAt: new Date('2022-01-01T00:00:00.000Z').toISOString(),
+          type: AggregateType.Widget,
+          name: 'Widget 1',
+          description: 'Description 1',
+          stock: 1,
+        },
+        {
+          aggregateId: aggregateId2,
+          createdAt: new Date('2022-01-02T00:00:00.000Z').toISOString(),
+          type: AggregateType.Widget,
+          name: 'Widget 2',
+          description: 'Description 2',
+          stock: 2,
+        },
+      ]
+      const result = widgets.sort((a, b) =>
+        (a.aggregateId ?? '').localeCompare(b.aggregateId ?? ''),
+      )
+      const expected = expectedWidgets.sort((a, b) =>
+        (a.aggregateId ?? '').localeCompare(b.aggregateId ?? ''),
+      )
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/test/infrastructure/widgetQueryDdbRepository.listWidgets.mock.test.ts
+++ b/test/infrastructure/widgetQueryDdbRepository.listWidgets.mock.test.ts
@@ -43,7 +43,7 @@ describe('WidgetQueryDdbRepository.listWidgets', () => {
             PK: aggregateId1,
             created: new Date('2022-01-01T00:00:00.000Z').toISOString(),
             type: AggregateType.Widget,
-            lastEvents: {
+            last_events: {
               1: {
                 created: new Date('2022-01-01T00:00:00.000Z').toISOString(),
                 name: DomainEventName.WidgetCreated,
@@ -60,7 +60,7 @@ describe('WidgetQueryDdbRepository.listWidgets', () => {
             PK: aggregateId2,
             created: new Date('2022-01-02T00:00:00.000Z').toISOString(),
             type: AggregateType.Widget,
-            lastEvents: {
+            last_events: {
               1: {
                 created: new Date('2022-01-02T00:00:00.000Z').toISOString(),
                 name: DomainEventName.WidgetCreated,


### PR DESCRIPTION
This pull request includes updates to the `WidgetQueryDdbRepository` and its associated tests to standardize the naming convention for event attributes and add new test cases for listing widgets. The most important changes include renaming attributes, updating test cases, and adding new tests for the `listWidgets` method.

Renaming attributes:

* [`src/infrastructure/widgetQueryDdbRepository.ts`](diffhunk://#diff-ad3cf90a0bf30aec0f12a0c54e234ad238533ecdb57ca5557d6d767c3a9c6c9bL50-R69): Changed `lastEvents` to `last_events` and `createdAt` to `created` to follow a consistent naming convention.

Updating test cases:

* [`test/infrastructure/widgetQueryDdbRepository.getWidgetById.db.test.ts`](diffhunk://#diff-313b5e9f38cb2d1fc53a41e75f5efacfef60ad2fe846b5e583765a42b61721f4L44-R46): Updated multiple instances of `lastEvents` to `last_events` and `createdAt` to `created` in the test cases to match the new naming convention. [[1]](diffhunk://#diff-313b5e9f38cb2d1fc53a41e75f5efacfef60ad2fe846b5e583765a42b61721f4L44-R46) [[2]](diffhunk://#diff-313b5e9f38cb2d1fc53a41e75f5efacfef60ad2fe846b5e583765a42b61721f4L89-R89) [[3]](diffhunk://#diff-313b5e9f38cb2d1fc53a41e75f5efacfef60ad2fe846b5e583765a42b61721f4L157-R159) [[4]](diffhunk://#diff-313b5e9f38cb2d1fc53a41e75f5efacfef60ad2fe846b5e583765a42b61721f4L179-R179)
* [`test/infrastructure/widgetQueryDdbRepository.listWidgets.mock.test.ts`](diffhunk://#diff-28a8ff8c2451982546804b5c554b0f289ab722be2044cd57a4c6cfb3f38b2854L46-R46): Updated instances of `lastEvents` to `last_events` in the mock test cases. [[1]](diffhunk://#diff-28a8ff8c2451982546804b5c554b0f289ab722be2044cd57a4c6cfb3f38b2854L46-R46) [[2]](diffhunk://#diff-28a8ff8c2451982546804b5c554b0f289ab722be2044cd57a4c6cfb3f38b2854L63-R63)

Adding new tests:

* [`test/infrastructure/widgetQueryDdbRepository.listWidgets.db.test.ts`](diffhunk://#diff-b008720cb6d2543f2a2059b4f6752e7a637ffa380a3e1c148b672526ea48706eR1-R123): Added new test cases for the `listWidgets` method to verify its behavior when there are no widgets and when there are some widgets.