### PR TITLE
Add WidgetDdbRepository with unimplemented methods for IWidgetRepository

### DIFF
--- a/src/infrastructure/widgetDdbRepository.ts
+++ b/src/infrastructure/widgetDdbRepository.ts
@@ -1,0 +1,17 @@
+import type {Widget} from '../domain/entities/widget'
+import type {IWidgetRepository} from '../domain/repositories/iWidgetRepository'
+
+export class WidgetDdbRepository implements IWidgetRepository {
+  findById(id: string): Promise<Widget> {
+    throw new Error('Method not implemented.')
+  }
+  findAll(): Promise<Widget[]> {
+    throw new Error('Method not implemented.')
+  }
+  save(widget: Widget): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  delete(id: string): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}


### PR DESCRIPTION
Introduce the `WidgetDdbRepository` class that implements the `IWidgetRepository` interface with placeholder methods.